### PR TITLE
Fix jira->github strikethrough

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,10 +15,10 @@ function toM() {
 
   converted = converted.replace(/\{\{(.*?)\}\}/g, '`$1`');
   converted = converted.replace(/\?\?(.*?)\?\?/g, '<cite>$1</cite>');
-  converted = converted.replace(/-(.*?)-/g, '~~$1~~');
   converted = converted.replace(/\+(.*?)\+/g, '<ins>$1</ins>');
   converted = converted.replace(/\^(.*?)\^/g, '<sup>$1</sup>');
   converted = converted.replace(/~(.*?)~/g, '<sub>$1</sub>');
+  converted = converted.replace(/-(.*?)-/g, '~~$1~~');
 
   converted = converted.replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```');
 


### PR DESCRIPTION
It was getting picked up by the later subscript replace, which took the strikethrough tildes and converted them again to `<sub>` tags. swapped them round and it appears to work after a quick test

before `-deleted-` would become `<sub></sub>deleted<sub></sub>`. now it correctly becomes `~~deleted~~`