### PR TITLE
Support converting multi-level Markdown unordered lists

### DIFF
--- a/src/J2M.js
+++ b/src/J2M.js
@@ -54,6 +54,14 @@
 			var to = (wrapper.length === 1) ? '_' : '*';
 			return to + content + to;
 		});
+		// Make multi-level bulleted lists work
+  		input = input.replace(/^(\s*)- (.*)$/gm, function (match,level,content) {
+    			var len = 2;
+    			if(level.length > 0) {
+        			len = parseInt(level.length/4.0) + 2;
+    			}
+    			return Array(len).join("-") + ' ' + content;
+  		});
 
 		var map = {
 			cite: '??',


### PR DESCRIPTION
This will convert Markdown lists like:

```
- Level 1
    - Level 2
- Level 1
```

to JIRA format like:

```
- Level 1
-- Level 2
- Level 1
```