### PR TITLE
Fixed bug with recursive transformation in blocks

### DIFF
--- a/src/J2M.js
+++ b/src/J2M.js
@@ -41,6 +41,23 @@
 	 * @returns {string}
 	 */
 	function toJ(input) {
+		// remove sections that shouldn't recursively processed
+		var START = 'J2MBLOCKPLACEHOLDER';
+		var replacementsList = [];
+		var counter = 0;
+		
+		input = input.replace(/`{3,}(\w+)?((?:\n|.)+?)`{3,}/g, function(match, synt, content) {
+		    var code = '{code';
+		
+		    if (synt) {
+		        code += ':' + synt;
+		    }
+		
+		    code += '}' + content + '{code}';
+		    var key = START + counter++ + '%%';
+		    replacementsList.push({key: key, value: code});
+		    return key;
+		});
 
 		input = input.replace(/^(.*?)\n([=-])+$/gm, function (match,content,level) {
 			return 'h' + (level[0] === '=' ? 1 : 2) + '. ' + content;
@@ -79,22 +96,16 @@
 
 		input = input.replace(/~~(.*?)~~/g, '-$1-');
 
-		input = input.replace(/`{3,}(\w+)?((?:\n|.)+?)`{3,}/g, function(match, synt, content) {
-			var code = '{code';
-
-			if (synt) {
-				code += ':' + synt;
-			}
-
-			code += '}' + content + '{code}';
-
-			return code;
-		});
-
 		input = input.replace(/`([^`]+)`/g, '{{$1}}');
 
 		input = input.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]');
 		input = input.replace(/<([^>]+)>/g, '[$1]');
+
+		// restore extracted sections
+		for(var i =0; i < replacementsList.length; i++){
+		    var sub = replacementsList[i];
+		    input = input.replace(sub["key"], sub["value"]);
+		}
 
 		return input;
 	};


### PR DESCRIPTION
Fixes #18 

Approach:
- moved handling of block to the top of transformation, to avoid to have them already replaced by other rules
- extract blocks from the original text, and store them in a datastructure.
- place a temporary placeholder in place of the original block
- delegate to the rest of the transformations
- replace temporary placeholders with the stashed ones