### PR TITLE
Support for images j2m and m2j

### DIFF
--- a/src/J2M.js
+++ b/src/J2M.js
@@ -26,6 +26,7 @@
 
 		input = input.replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```');
 
+		input = input.replace(/!([^\n\s]+)!/, '![]($1)');
 		input = input.replace(/\[(.+?)\|(.+)\]/g, '[$1]($2)');
 		input = input.replace(/\[(.+?)\]([^\(]*)/g, '<$1>$2');
 
@@ -138,6 +139,7 @@
 
 		input = input.replace(/~~(.*?)~~/g, '-$1-');
 
+		input = input.replace(/!\[[^\]]+\]\(([^)]+)\)/g, '!$1!');
 		input = input.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '[$1|$2]');
 		input = input.replace(/<([^>]+)>/g, '[$1]');
 


### PR DESCRIPTION
Fixes #29 

----

I just included the following changes:

- `toM`: replacing `!this!` into `![](this)`, for images. In order to avoid capturing `something! like! this!` I restricted the contents of the expression to not include newlines or space characters.
- `toJ`: replacing `![text](url)` into `!url!`

I apologize for submitting #29 too -- I did not realize at the time that the repository was not being maintained. That given, I truly appreciate the prompt response and the encouragement to submit the PR. :)

Thanks!