### PR TITLE
fix links

### DIFF
--- a/src/J2M.js
+++ b/src/J2M.js
@@ -27,7 +27,7 @@
 		input = input.replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```');
 
 		input = input.replace(/!([^\n\s]+)!/, '![]($1)');
-		input = input.replace(/\[([^|]+)\|(.+)\]/g, '[$1]($2)');
+		input = input.replace(/\[([^|]+)\|(.+?)\]/g, '[$1]($2)');
 		input = input.replace(/\[(.+?)\]([^\(]+)/g, '<$1>$2');
 
 		input = input.replace(/{noformat}/g, '```');

--- a/src/J2M.js
+++ b/src/J2M.js
@@ -27,8 +27,8 @@
 		input = input.replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```');
 
 		input = input.replace(/!([^\n\s]+)!/, '![]($1)');
-		input = input.replace(/\[(.+?)\|(.+)\]/g, '[$1]($2)');
-		input = input.replace(/\[(.+?)\]([^\(]*)/g, '<$1>$2');
+		input = input.replace(/\[([^|]+)\|(.+)\]/g, '[$1]($2)');
+		input = input.replace(/\[(.+?)\]([^\(]+)/g, '<$1>$2');
 
 		input = input.replace(/{noformat}/g, '```');
 


### PR DESCRIPTION
fixes #32 

Pre-fix test cases

```
$ ./src/bin/j2m.js --stdin --toM <<<'[http://link/path] [text2|http://link2/path] [text3|http://link3/path]'
<http://link/path> [text2](http://link2/path] [text3|http://link3/path)

$ ./src/bin/j2m.js --stdin --toM <<<'[text|http://link]
[text2|http://link2]
[text3|http://link3]

[text4|http://link4]
'
<text>(http://link)
<text2>(http://link2)
<text3>(http://link3)

<text4>(http://link4)


```

Post-fix tests

```
$ ./src/bin/j2m.js --stdin --toM <<<'[http://link/path] [text2|http://link2/path] [text3|http://link3/path]'
<http://link/path> [text2](http://link2/path) [text3](http://link3/path)

$ ./src/bin/j2m.js --stdin --toM <<<'[text|http://link]
[text2|http://link2]
[text3|http://link3]

[text4|http://link4]
'
[text](http://link)
[text2](http://link2)
[text3](http://link3)

[text4](http://link4)


```